### PR TITLE
Remove PropTypes to solve errors with React 18

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import {View, ViewPropTypes} from 'react-native';
 import {merge, isEqual, isArray} from 'lodash';
-import PropTypes from 'prop-types';
+import PropTypes from 'deprecated-react-native-prop-types';
 import SimpleMarkdown from 'simple-markdown';
 import styles from './styles';
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 import React, {Component} from 'react';
 import {View} from 'react-native';
 import {merge, isEqual, isArray} from 'lodash';
-import PropTypes, {ViewPropTypes} from 'deprecated-react-native-prop-types';
 import SimpleMarkdown from 'simple-markdown';
 import styles from './styles';
 
@@ -54,23 +53,6 @@ class Markdown extends Component {
 
     return <View style={[styles.view, this.props.styles.view]}>{this.renderer(tree)}</View>
   }
-}
-
-Markdown.propTypes = {
-  enableLightBox: PropTypes.bool,
-  onLink: PropTypes.func,
-  onImageOpen: PropTypes.func,
-  onImageClose: PropTypes.func,
-  onLoad: PropTypes.func,
-  styles: PropTypes.shape({
-    view: ViewPropTypes.style,
-  }),
-  rules: PropTypes.object,
-};
-
-Markdown.defaultProps = {
-  styles: styles,
-  rules: {}
 }
 
 export default Markdown;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
-import {View, ViewPropTypes} from 'react-native';
+import {View} from 'react-native';
 import {merge, isEqual, isArray} from 'lodash';
-import PropTypes from 'deprecated-react-native-prop-types';
+import PropTypes, {ViewPropTypes} from 'deprecated-react-native-prop-types';
 import SimpleMarkdown from 'simple-markdown';
 import styles from './styles';
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "lodash": "^4.17.15",
-    "prop-types": "^15.6.0",
     "react-native-lightbox": "^0.7.0",
     "simple-markdown": "^0.7.1",
     "deprecated-react-native-prop-types": "2.2.0"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "dependencies": {
     "lodash": "^4.17.15",
     "react-native-lightbox": "^0.7.0",
-    "simple-markdown": "^0.7.1",
-    "deprecated-react-native-prop-types": "2.2.0"
+    "simple-markdown": "^0.7.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.6.0",
     "react-native-lightbox": "^0.7.0",
-    "simple-markdown": "^0.7.1"
+    "simple-markdown": "^0.7.1",
+    "deprecated-react-native-prop-types": "2.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Goal: 

This PR was made in order to solve numerous errors related to the usage of this lib. with React 18.

## Solution:

Removing `PropTypes` from project

## Future ideas:

Introduce TypeScript to achieve the same validation behaviour