### PR TITLE
apply default text styles to the bullet and list numbers

### DIFF
--- a/rules.js
+++ b/rules.js
@@ -195,10 +195,10 @@ module.exports = function (styles, opts = {}) {
           state.withinList = false;
           
           if (node.ordered) {
-            bullet = React.createElement(Text, {key: 0, style: styles.listItemNumber}, (numberIndex) + '. ');
+            bullet = React.createElement(Text, {key: 0, style: [styles.text, styles.listItemNumber]}, (numberIndex) + '. ');
           }
           else {
-            bullet = React.createElement(Text, {key: 0, style: styles.listItemBullet}, '\u2022 ');
+            bullet = React.createElement(Text, {key: 0, style: [styles.text, styles.listItemBullet]}, '\u2022 ');
           }
 
           if (item.length > 1) {
@@ -241,10 +241,10 @@ module.exports = function (styles, opts = {}) {
         var items = map(node.items, function (item, i) {
           var bullet;
           if (node.ordered) {
-            bullet = React.createElement(Text, {key: 0, style: styles.listItemNumber}, (i + 1) + '. ');
+            bullet = React.createElement(Text, {key: 0, style: [styles.text, styles.listItemNumber]}, (i + 1) + '. ');
           }
           else {
-            bullet = React.createElement(Text, {key: 0, style: styles.listItemBullet}, '\u2022 ');
+            bullet = React.createElement(Text, {key: 0, style: [styles.text, styles.listItemBullet]}, '\u2022 ');
           }
 
           var content = output(item, state);

--- a/styles.js
+++ b/styles.js
@@ -105,7 +105,7 @@ export default StyleSheet.create({
     lineHeight: 20,
   },
   listItemNumber: {
-    fontWeight: 'bold',
+    fontWeight: 'normal', // unnecessary 'normal' - just keeping the style name documented
   },
   listRow: {
     flexDirection: 'row',


### PR DESCRIPTION
I felt like if the default text styles like font style  size is changed, the bullets and numbered list numbers should also match to the default text styles automatically. Though I am aware we can override it using `listItemNumber` and `listItemBullet` styles. But thought this should be handled automatically and override only if necessary.

<img width="326" alt="Screenshot 2022-11-14 at 7 58 37 PM" src="https://user-images.githubusercontent.com/13726932/201855362-13699406-7452-468e-ad35-704e690959f6.png">
Above image shows how the current default behaviour where the `listItemNumber` and `listItemBullet` don't match to default style.