### PR TITLE
fix: removed undefined props on main View style props

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ class Markdown extends Component {
 
     const tree = this.parse(child);
 
-    return <View style={[styles.view, this.props.styles.view]}>{this.renderer(tree)}</View>
+    return <View style={[styles.view, this.props.styles]}>{this.renderer(tree)}</View>
   }
 }
 


### PR DESCRIPTION
Hi there,

I've made a small bugfix to the main render component of the library. Specifically, I removed an undefined property that was being passed in the style prop of the view. This should resolve the issue and improve the overall functionality of the component.

Thanks for considering my contribution! Let me know if you have any questions or concerns.

Best regards,
Simone